### PR TITLE
Left justify cards on Index page

### DIFF
--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -26,7 +26,7 @@ export default function IndexPage({ data }) {
         </p>
       </Hero>
       <Container forwardedAs="section" my={5}>
-        <Box row m={-3} justifyContent="center">
+        <Box row m={-3} justifyContent="left">
           {data.allTemplate.edges.map(({ node: template }) => (
             <Box key={template.id} col={{ xs: 1, md: 1 / 3 }} p={3}>
               <Card>


### PR DESCRIPTION
* This comes down to personal preference but it might be better to left justify the row of cards on desktop. 

**Centered**
<img width="1192" alt="center" src="https://user-images.githubusercontent.com/5171579/72851293-12e8e000-3c60-11ea-9e15-e851f34f6bcc.png">

**Left Justified**
<img width="1183" alt="left" src="https://user-images.githubusercontent.com/5171579/72851304-1e3c0b80-3c60-11ea-9cb4-4cfc0854cde0.png">
